### PR TITLE
Fix typo in "Editor not found" error message

### DIFF
--- a/files.go
+++ b/files.go
@@ -117,7 +117,7 @@ func CreateAndOpenFile(labdir string, prefix string, extension string, editor st
 	err = cmd.Run()
 	if err != nil {
 		if strings.Contains(err.Error(), "executable file not found") {
-			fmt.Printf("\n  Editor %s not found. \n  \033[33mSet your preferred editor in %s/.lab\033[0m (examples below):\n\n\teditor=code    # for VS Code\n\teditor=nvim    # for Neovim\n\teditor=vim     # for Vim\n\n", editor, displayPath)
+			fmt.Printf("\n  Editor %s not found. \n  \033[33mSet your preferred editor in %s.lab\033[0m (examples below):\n\n\teditor=code    # for VS Code\n\teditor=nvim    # for Neovim\n\teditor=vim     # for Vim\n\n", editor, displayPath)
 			os.Remove(file)
 			return
 		}


### PR DESCRIPTION
Following on to #5, after 3cf1854dc06d97ad87b2ea9ec68176179ab13bf8 there is still a minor typo:
```shell
> echo $LABPATH
/Users/xkrogen/dev

> lab py

  Editor nvim not found.
  Set your preferred editor in ~/dev/lab//.lab (examples below):

        editor=code    # for VS Code
        editor=nvim    # for Neovim
        editor=vim     # for Vim

> unset LABPATH

> lab py

  Editor nvim not found.
  Set your preferred editor in ~/lab//.lab (examples below):

        editor=code    # for VS Code
        editor=nvim    # for Neovim
        editor=vim     # for Vim
```

Note that the other place this error string occurs is already correct:
https://github.com/lugenx/lab/blob/d056b877382026327a33d0b59032c155f12e7c03/files.go#L237